### PR TITLE
Fixed README .env Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,14 @@ git clone git@github.com:descope-sample-apps/b2c-retail-sample-app.git
 
 #### 2. Set up Descope environment variables in `.env` file
 ```
-REACT_APP_DESCOPE_PROJECT_ID="YOUR PROJECT ID" // Required for Descope authentication
-REACT_APP_DESCOPE_SIGN_IN_FLOW_ID="sign-up-or-in" // Optional, if you would like to use a flow other than sign-up-or-in
-REACT_APP_DESCOPE_MANAGEMENT_KEY="YOUR MANAGEMENT KEY" // Optional, if you would like to run E2E tests
+# Required for Descope authentication
+REACT_APP_DESCOPE_PROJECT_ID="YOUR_PROJECT_ID"
+
+# Optional, if you would like to use a flow other than sign-up-or-in
+REACT_APP_DESCOPE_SIGN_IN_FLOW_ID="sign-up-or-in"
+
+# Optional, if you would like to run E2E tests
+REACT_APP_DESCOPE_MANAGEMENT_KEY="YOUR_MANAGEMENT_KEY"
 ```
 _You can get your project-id [here](https://app.descope.com/settings/project)_.
 _You can get this flow-id from the Flows page [here](https://app.descope.com/flows)_.


### PR DESCRIPTION
These .env variables were not easily copyable with the comments, so this was fixed.